### PR TITLE
16 fix unicode characters in the board display not rendering on windows

### DIFF
--- a/src/SplooshController.cs
+++ b/src/SplooshController.cs
@@ -16,6 +16,9 @@ namespace Sploosh_Console
             bool fire;
             board.PlaceShipsRandomly();
 
+            boardView.homeRow = Console.CursorTop;
+            boardView.homeCol = Console.CursorLeft;
+
             while (!GameWon())
             {
                 boardView.Update();

--- a/src/SplooshController.cs
+++ b/src/SplooshController.cs
@@ -1,4 +1,4 @@
-﻿using SplooshUtil;
+﻿using System.Runtime.InteropServices;
 
 namespace Sploosh_Console
 {
@@ -8,6 +8,10 @@ namespace Sploosh_Console
         static GameBoard board = new(8,8);
         public static void Main()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)){
+                Console.OutputEncoding = System.Text.Encoding.Unicode;
+            }
+            
             SplooshView boardView = new(board);
             bool fire;
             board.PlaceShipsRandomly();

--- a/src/SplooshController.cs
+++ b/src/SplooshController.cs
@@ -19,6 +19,8 @@ namespace Sploosh_Console
             boardView.homeRow = Console.CursorTop;
             boardView.homeCol = Console.CursorLeft;
 
+            Console.CursorVisible = false;
+
             while (!GameWon())
             {
                 boardView.Update();

--- a/src/SplooshController.cs
+++ b/src/SplooshController.cs
@@ -15,7 +15,7 @@ namespace Sploosh_Console
             SplooshView boardView = new(board);
             bool fire;
             board.PlaceShipsRandomly();
-
+            Console.Clear();
             boardView.homeRow = Console.CursorTop;
             boardView.homeCol = Console.CursorLeft;
 

--- a/src/SplooshController.cs
+++ b/src/SplooshController.cs
@@ -62,6 +62,8 @@ namespace Sploosh_Console
             boardView.showCursor = false;
             boardView.Update();
             Console.WriteLine("Game won. 'Grats man.");
+            Console.WriteLine("Press any key to quit...");
+            Console.ReadKey(true);
         }
 
     private static bool GameWon(){

--- a/src/view/SplooshView.cs
+++ b/src/view/SplooshView.cs
@@ -12,6 +12,9 @@ class SplooshView
     public int boardCursorRow = 0;
     public int boardCursorCol = 0;
 
+    public int homeRow = 0;
+    public int homeCol = 0;
+
     public SplooshView(GameBoard boardIn)
     {
         gb = boardIn;
@@ -141,7 +144,7 @@ class SplooshView
 
     public void Update()
     {
-        Console.Clear();
+        Console.SetCursorPosition(homeCol, homeRow);
         string gridString = CompileLayers();
         Console.WriteLine(gridString);
     }

--- a/src/view/SplooshView.cs
+++ b/src/view/SplooshView.cs
@@ -116,7 +116,7 @@ class SplooshView
                     charCol += 1;
                 }
 
-                grid[GetRowChars(r), charCol] = (resultMap[r, c] == 1) ? '⨉' : (resultMap[r, c] == 2) ? '*' : grid[GetRowChars(r), charCol];
+                grid[GetRowChars(r), charCol] = (resultMap[r, c] == 1) ? '○' : (resultMap[r, c] == 2) ? '✶' : grid[GetRowChars(r), charCol];
             }
         }
     }


### PR DESCRIPTION
- Closes #16 

## What?
- The console output encoding is now set to Unicode (UTF-8) on Windows platforms.
- Instead of calling Console.Clear() every time, the console's cursor is returned to the top left of the board display. This causes the next frame of the display to overwrite the old one.
- Added a Console.ReadKey() prompt when the game ends.
- Changes the unicode characters used for hit/miss indicators for improved compatibility and readability.
## Why?
- The unicode characters used to represent misses and ships in the board display were incorrectly rendering as '?' characters on Windows. 
- Explicitly setting the encoding of the console output to unicode when the game is executed on Windows caused the affected unicode characters to render correctly again. This approach was found in the console class documentation [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-console). 
- Reducing multiple calls to Console.Clear() prevents the display flickering on Windows consoles (see this [SO post](https://stackoverflow.com/questions/67850823/console-flickering-on-redraw).)